### PR TITLE
New packets type definitions

### DIFF
--- a/protocol.h
+++ b/protocol.h
@@ -17,6 +17,8 @@
 typedef enum {
     E_NETWORK_PACKET_CONTROLLER,
     E_NETWORK_PACKET_IN_REPORT,
+    E_NETWORK_PACKET_EXIT,
+    E_NETWORK_PACKET_SETCONFIG,
 } e_network_packet_type;
 
 typedef struct PACKED
@@ -35,5 +37,13 @@ typedef struct PACKED
   uint8_t packet_type; // E_NETWORK_PACKET_CONTROLLER
   uint8_t controller_type;
 } s_network_packet_controller;
+
+typedef struct PACKED
+{
+  uint8_t packet_type;
+  float sensibility;
+  int16_t dead_zone_X;
+  int16_t dead_zone_Y;
+}s_network_packet_config;
 
 #endif /* GIMX_NETWORK_PROTOCOL_H_ */

--- a/protocol.h
+++ b/protocol.h
@@ -20,6 +20,7 @@ typedef enum {
     E_NETWORK_PACKET_EXIT,
     E_NETWORK_PACKET_SETCONFIG,
     E_NETWORK_PACKET_GETCONFIG,
+    E_NETWORK_PACKET_SAVECALIBRATION, 
 } e_network_packet_type;
 
 typedef struct PACKED

--- a/protocol.h
+++ b/protocol.h
@@ -19,6 +19,7 @@ typedef enum {
     E_NETWORK_PACKET_IN_REPORT,
     E_NETWORK_PACKET_EXIT,
     E_NETWORK_PACKET_SETCONFIG,
+    E_NETWORK_PACKET_GETCONFIG,
 } e_network_packet_type;
 
 typedef struct PACKED

--- a/protocol.h
+++ b/protocol.h
@@ -40,12 +40,19 @@ typedef struct PACKED
   uint8_t controller_type;
 } s_network_packet_controller;
 
+/**
+ * When adding new attributes to this struct, add it to the end.
+ */
 typedef struct PACKED
 {
   uint8_t packet_type;
   float sensibility;
-  int16_t dead_zone_X;
-  int16_t dead_zone_Y;
+  int16_t dead_zone_x;
+  int16_t dead_zone_y;
+  float yx_ratio;
+  float exponent_x;
+  float exponent_y;
+
 }s_network_packet_config;
 
 #endif /* GIMX_NETWORK_PROTOCOL_H_ */


### PR DESCRIPTION
See https://github.com/Lucashsmello/GIMX/wiki/Network-api-extended for details.

Notes:
- I assumed that float data type is always 4 bytes.
- `struct s_network_packet_config` is used to receive configuration settings as well as to send configuration settings.